### PR TITLE
Add API path as parameter for the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A wrapper for the mod.io API in Python.
 ```py
 import modio
 
-client = modio.Client(api_key="your api key here", access_token="your o auth 2 token here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)",  api_key="your api key here", access_token="your o auth 2 token here")
 
 game = client.get_game(345)
 #gets the game with id 345
@@ -36,7 +36,7 @@ To perform writes, you will need to authenticate your users via OAuth 2. To make
 ```py
 import modio
 
-client = modio.Client(api_key="your api key here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", api_key="your api key here")
 
 #request a security code be sent at this email adress
 client.email_request("necro@mordor.com")

--- a/examples/filter.py
+++ b/examples/filter.py
@@ -1,6 +1,6 @@
 import modio
 
-client = modio.Client(api_key="api key goes here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", api_key="api key goes here")
 filters = modio.Filter()
 
 filters.text("The Lord of the Rings")

--- a/examples/newfile.py
+++ b/examples/newfile.py
@@ -1,6 +1,6 @@
 import modio
 
-client = modio.Client(access_token="oauth2 token goes here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", access_token="oauth2 token goes here")
 newfile = modio.NewModFile(
     version="0.3.4",
     changelog="New version which now contains <b> twice as many toilets </b>",

--- a/examples/newmod.py
+++ b/examples/newmod.py
@@ -1,6 +1,6 @@
 import modio
 
-client = modio.Client(access_token="oauth2 token goes here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", access_token="oauth2 token goes here")
 newmod = modio.NewMod(
     name="A LOTR Toilet Mod",
     name_id="lotr-toilets",

--- a/examples/oauth2.py
+++ b/examples/oauth2.py
@@ -1,7 +1,7 @@
 # This example shows how to gain an OAuth 2 Access Token through the Email Authentication Flow to gain Write access
 import modio
 
-client = modio.Client(api_key="your api key here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", api_key="your api key here")
 
 # request a security code be sent at this email adress
 client.email_request("necro@mordor.com")

--- a/examples/polling_events.py
+++ b/examples/polling_events.py
@@ -1,6 +1,6 @@
 import modio
 
-client = modio.Client(api_key="api key goes here")
+client = modio.Client(api_path="api path goes here (eg. g-123 or u-123)", api_key="api key goes here")
 game = client.get_game(947)
 
 MOD_ID = 9084

--- a/modio/__init__.py
+++ b/modio/__init__.py
@@ -7,4 +7,4 @@ from .objects import NewMod, NewModFile, Object, Filter
 from .enums import *
 from .errors import *
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/modio/__init__.py
+++ b/modio/__init__.py
@@ -6,5 +6,6 @@ from .client import Client
 from .objects import NewMod, NewModFile, Object, Filter
 from .enums import *
 from .errors import *
+from .mod import *
 
 __version__ = "0.6.1"

--- a/modio/client.py
+++ b/modio/client.py
@@ -26,9 +26,10 @@ MAX_TRIES = 2
 class Connection:
     """Class handling under the hood requests and ratelimits."""
 
-    def __init__(self, api_key, access_token, lang, version, test, platform, portal, ratelimit_max_sleep):
+    def __init__(self, api_path, api_key, access_token, lang, version, test, platform, portal, ratelimit_max_sleep):
         self.test = test
         self.version = version
+        self.api_path = api_path
         self.access_token = access_token
         self.api_key = api_key
         self.lang = lang
@@ -57,9 +58,9 @@ class Connection:
     @property
     def _base_path(self):
         if self.test:
-            return f"https://api.test.mod.io/{self.version}"
+            return f"https://{self.api_path}.test.mod.io/{self.version}"
 
-        return f"https://api.mod.io/{self.version}"
+        return f"https://{self.api_path}.modapi.io/{self.version}"
 
     def __repr__(self):
         return f"<Connection retry_after={self.retry_after}>"
@@ -299,6 +300,7 @@ class Client:
     def __init__(
         self,
         *,
+        api_path=None,
         api_key=None,
         access_token=None,
         lang="en",
@@ -313,6 +315,7 @@ class Client:
         self.test = test
         self.connection = Connection(
             test=test,
+            api_path=api_path,
             api_key=api_key,
             access_token=access_token,
             version=version,

--- a/modio/entities.py
+++ b/modio/entities.py
@@ -1,5 +1,6 @@
 """Module for miscs objects."""
 import time
+import json
 
 from .mixins import OwnerMixin, RatingMixin, ReportMixin, StatsMixin
 from .errors import modioException
@@ -404,6 +405,70 @@ class ModFile(OwnerMixin):
             f"/games/{self.game_id}/mods/{self.mod}/files/{self.id}"
         )
         return resp
+
+
+    def manage_platforms(self, approved:list[str]=None, denied:list[str]=None):
+        """Manage the platform status of this mod file. Returns an updated
+            instances of the file.
+
+            Parameters
+            -----------
+            approved : str
+                Change the release version of the file
+            denied : str
+                Change the changelog of this release
+
+            Returns
+            --------
+            ModFile
+                The updated file
+            """
+
+        if approved is None:
+            approved = []
+        if denied is None:
+            denied = []
+
+        if not self.game_id:
+            raise modioException(
+                "This endpoint cannot be used for ModFile object recuperated through the me/modfiles endpoint"
+            )
+
+        data = {}
+        for index in range(0, len(approved)):
+            data[f"approved[{index}]"] = approved[index]
+        for index in range(0, len(denied)):
+            data[f"denied[{index}]"] = denied[index]
+
+        file_json = self.connection.post_request(
+            f"/games/{self.game_id}/mods/{self.mod}/files/{self.id}/platforms", data=data
+        )
+
+        return self.__class__(connection=self.connection, game_id=self.game_id, **file_json)
+
+    async def manage_platforms_async(self, approved:list[str]=None, denied:list[str]=None):
+        if approved is None:
+            approved = []
+        if denied is None:
+            denied = []
+
+        if not self.game_id:
+            raise modioException(
+                "This endpoint cannot be used for ModFile object recuperated through the me/modfiles endpoint"
+            )
+
+        data = {}
+        for index in range(0, len(approved)):
+            data[f"approved[{index}]"] = approved[index]
+        for index in range(0, len(denied)):
+            data[f"denied[{index}]"] = denied[index]
+
+        file_json = await self.connection.async_post_request(
+            f"/games/{self.game_id}/mods/{self.mod}/files/{self.id}/platforms", data=data
+        )
+
+        return self.__class__(connection=self.connection, game_id=self.game_id, **file_json)
+
 
     def url_is_expired(self):
         """Check if the url is still valid for this modfile.

--- a/modio/enums.py
+++ b/modio/enums.py
@@ -74,6 +74,7 @@ class ModFilePlatformStatus(enum.Enum):
     pending = 0
     accepted = 1
     denied = 2
+    targetted = 3
 
 
 class Presentation(enum.Enum):


### PR DESCRIPTION
As of the in April mentioned change of URL in issue #29 an `api_path` parameter was introduced.
This implementation only needs the subdomain part of the path to be able to still support the test flag. If the client should take the complete URL then the `test` flag would become obsolete and testing has to be managed by the project that uses this library.
There could also be some URL parsing that rewrites the URL to a testing URL but was not considered here.

I've bumped the patch version number by one and adjusted the examples and readme to address for the additional `api_path` parameter.